### PR TITLE
Allow pot querying for joint accounts

### DIFF
--- a/monzo/monzo-in.html
+++ b/monzo/monzo-in.html
@@ -216,7 +216,9 @@
         defaults: {
             name:{value:""},
             monzocreds: {type:"monzo-credentials",required:true},
-            requesttype:{value:"accounts"}
+            requesttype:{value:"accounts"},
+            potid:{value: ""},
+            accountid:{value: ""}
         },
         inputs:1,
         outputs:1,
@@ -226,6 +228,22 @@
         },
         paletteLabel:function(){
             return "monzo in";
+        },
+        oneditprepare: function(){
+            $('#node-input-requesttype').on("change", function(e){
+                $('.hidden-row-item').hide();
+                var val = $(this).val();
+                if(val == "pot"){
+                    $('.pot-row').show();
+                }else{
+                    $('.pot-row').hide();
+                }
+                if(val == "pot" || val == "pots"){
+                    $('.accountid-row').show();
+                }else{
+                    $('.accountid-row').hide();
+                }
+            });
         }
     });
 </script>
@@ -241,10 +259,19 @@
     <div class="form-row">
         <label for="node-input-requesttype"><i class="icon-tag"></i> Request</label>
         <select id="node-input-requesttype">
-            <option value="accounts">all accounts</>
-            <option value="balances">all balances</>
-            <option value="pots">all pots</>
+            <option value="accounts">all accounts</option>
+            <option value="balances">all balances</option>
+            <option value="pots">all pots</option>
+            <option value="pot">specific pot</option>
         </select>
+    </div>
+    <div class="form-row pot-row" style="display:none;">
+            <label for="node-input-potid"><i class="icon-tag"></i> Pot Id</label>
+            <input type="text" id="node-input-potid">
+    </div>
+    <div class="form-row accountid-row" style="display:none;">
+            <label for="node-input-accountid"><i class="icon-tag"></i> AccountID</label>
+            <input type="text" id="node-input-accountid">
     </div>
 </script>
 <script data-help-name="monzo-in" type="text/x-red">

--- a/monzo/monzo-webhook.js
+++ b/monzo/monzo-webhook.js
@@ -4,34 +4,38 @@ module.exports = function(RED) {
     /*
     Setup MonzoWebHook
      */
+
+    
     function MonzoWebHookNode(config) {
         RED.nodes.createNode(this, config);
         var node = this;
         this.monzoConfig = RED.nodes.getNode(config.monzocreds);
         var monzocredentials = RED.nodes.getCredentials(config.monzocreds);
 
-        //Set up the endpoint to receive "Local" webhook messages
-        RED.httpAdmin.post(('/monzo-webhook/' + node.id), function(req, res) {
-            const Monzo = require('monzo-js');
-            var monzocredentials_local = RED.nodes.getCredentials(config.monzocreds);
-            const monzo = new Monzo(monzocredentials_local.token);
-            try {
-                //console.log(req.body);
-                if (req.body != "{}") {
-                    var hookdata = req.body;
-                    var msg = {
-                        payload: hookdata
-                    };
-                    node.send(msg);
+        function WebhookCallback(req, res){            
+                const Monzo = require('monzo-js');
+                var monzocredentials_local = RED.nodes.getCredentials(config.monzocreds);
+                const monzo = new Monzo(monzocredentials_local.token);
+                try {
+                    //console.log(req.body);
+                    if (req.body != "{}") {
+                        var hookdata = req.body;
+                        var msg = {
+                            payload: hookdata
+                        };
+                        node.send(msg);
+                    }
+                } catch (err) {
+                    node.error(err);
                 }
-            } catch (err) {
-                node.error(err);
-            }
-            res.end("done");
-        });
-
+                res.end("done");
+        }
+        
         //Set up endpoint to allow you to retreive active webhooks within the admin (REQUIRES PERMISSIONS IF SET)
-        RED.httpAdmin.get('/monzo-get-hooks', RED.auth.needsPermission('monzo-hook.read'), function(req, res) {
+        //Set up the endpoint to receive "Local" webhook messages
+        var obj = RED.httpAdmin.post(('/monzo-webhook/' + node.id), function(req, res){  WebhookCallback(req, res); } );
+
+        function GetHooksCallback(req, res) {
             const Monzo = require('monzo-js');
             var monzocredentials_local = RED.nodes.getCredentials(config.monzocreds);
             const monzo = new Monzo(monzocredentials_local.token);
@@ -51,10 +55,12 @@ module.exports = function(RED) {
                 res.send(error);
                 //console.log(error);
             });
-        });
+        }
 
-        //Set up endpoint to allow you to delete a webhook through the admin, (REQUIRES PERMISSIONS IF SET)
-        RED.httpAdmin.get('/monzo-delete-hook/:id', RED.auth.needsPermission('monzo-hook.read'), function(req, res) {
+        //Set up endpoint to allow you to retreive active webhooks within the admin (REQUIRES PERMISSIONS IF SET)
+        RED.httpAdmin.get('/monzo-get-hooks', RED.auth.needsPermission('monzo-hook.read'), function(req, res){ GetHooksCallback(req, res) });
+
+        function DeleteHookCallback(req, res) {
             const Monzo = require('monzo-js');
             var monzocredentials_local = RED.nodes.getCredentials(config.monzocreds);
             const monzo = new Monzo(monzocredentials_local.token);
@@ -76,7 +82,12 @@ module.exports = function(RED) {
                     res.send("deleted");
                 }
             });
-        });
+        }
+
+        //Set up endpoint to allow you to delete a webhook through the admin, (REQUIRES PERMISSIONS IF SET)
+        RED.httpAdmin.get('/monzo-delete-hook/:id', RED.auth.needsPermission('monzo-hook.read'), function(req, res){ DeleteHookCallback(req. res_)} );
+
+
 
         if (this.monzoConfig) {
             if (monzocredentials.token != "") {


### PR DESCRIPTION
Added ability to define accountId on Monzo-In when querying Pots, and added ability to query a specific pot - and added Goal Amount to the response json.

I've also made changes to your forked monzojs to support this which I'll issue a pull request for too.

My fix to the webhook was done in my master, so this pull request has that in - I'm not sure what the right thing to do is in this context? Should I rebase, or does it matter as long as you merge the webhook fix first?