### PR TITLE
Fix for webhook dying after deploy #5

### DIFF
--- a/monzo/monzo-webhook.html
+++ b/monzo/monzo-webhook.html
@@ -1,7 +1,7 @@
 <script type="text/javascript">
 
 
-    function get_monzo_hooks(){
+    function get_monzo_hooks(node){
 
         var headers_dat = "";
         if (localStorage.getItem("auth-tokens") !== null) {
@@ -9,10 +9,8 @@
             tokens = JSON.parse(localStorage.getItem("auth-tokens"))
             headers_dat = "Bearer "+tokens.access_token
         }
-
-
         $.ajax({
-                   url: "/monzo-get-hooks",
+                   url: "/monzo-get-hooks/" + node.id,
                    beforeSend: function(request) {
                         if(headers_dat != ""){
                             request.setRequestHeader("Authorization", headers_dat);
@@ -41,7 +39,7 @@
                                 $(deletebtn).click(function(){
                                     var clickbtn = this;
                                     $.ajax({
-                                       url: "/monzo-delete-hook/"+$(this).attr("hookid"),
+                                       url: "/monzo-delete-hook/"+node.id+"/"+$(this).attr("hookid"),
                                        beforeSend: function(request) {
                                         if(headers_dat != ""){
                                             request.setRequestHeader("Authorization", headers_dat);
@@ -115,8 +113,8 @@
                 }
             });
 
-            
-            get_monzo_hooks();
+            var node = this;
+            get_monzo_hooks(node);
                 
 
          }

--- a/monzo/monzo-webhook.js
+++ b/monzo/monzo-webhook.js
@@ -4,34 +4,38 @@ module.exports = function(RED) {
     /*
     Setup MonzoWebHook
      */
+
+    
     function MonzoWebHookNode(config) {
         RED.nodes.createNode(this, config);
         var node = this;
         this.monzoConfig = RED.nodes.getNode(config.monzocreds);
         var monzocredentials = RED.nodes.getCredentials(config.monzocreds);
 
-        //Set up the endpoint to receive "Local" webhook messages
-        RED.httpAdmin.post(('/monzo-webhook/' + node.id), function(req, res) {
-            const Monzo = require('monzo-js');
-            var monzocredentials_local = RED.nodes.getCredentials(config.monzocreds);
-            const monzo = new Monzo(monzocredentials_local.token);
-            try {
-                //console.log(req.body);
-                if (req.body != "{}") {
-                    var hookdata = req.body;
-                    var msg = {
-                        payload: hookdata
-                    };
-                    node.send(msg);
+        function WebhookCallback(req, res){            
+                const Monzo = require('monzo-js');
+                var monzocredentials_local = RED.nodes.getCredentials(config.monzocreds);
+                const monzo = new Monzo(monzocredentials_local.token);
+                try {
+                    //console.log(req.body);
+                    if (req.body != "{}") {
+                        var hookdata = req.body;
+                        var msg = {
+                            payload: hookdata
+                        };
+                        node.send(msg);
+                    }
+                } catch (err) {
+                    node.error(err);
                 }
-            } catch (err) {
-                node.error(err);
-            }
-            res.end("done");
-        });
-
+                res.end("done");
+        }
+        
         //Set up endpoint to allow you to retreive active webhooks within the admin (REQUIRES PERMISSIONS IF SET)
-        RED.httpAdmin.get('/monzo-get-hooks', RED.auth.needsPermission('monzo-hook.read'), function(req, res) {
+        //Set up the endpoint to receive "Local" webhook messages
+        var obj = RED.httpAdmin.post(('/monzo-webhook/' + node.id), function(req, res){  WebhookCallback(req, res); } );
+
+        function GetHooksCallback(req, res) {
             const Monzo = require('monzo-js');
             var monzocredentials_local = RED.nodes.getCredentials(config.monzocreds);
             const monzo = new Monzo(monzocredentials_local.token);
@@ -51,10 +55,12 @@ module.exports = function(RED) {
                 res.send(error);
                 //console.log(error);
             });
-        });
+        }
 
-        //Set up endpoint to allow you to delete a webhook through the admin, (REQUIRES PERMISSIONS IF SET)
-        RED.httpAdmin.get('/monzo-delete-hook/:id', RED.auth.needsPermission('monzo-hook.read'), function(req, res) {
+        //Set up endpoint to allow you to retreive active webhooks within the admin (REQUIRES PERMISSIONS IF SET)
+        RED.httpAdmin.get('/monzo-get-hooks', RED.auth.needsPermission('monzo-hook.read'), function(req, res){ GetHooksCallback(req, res) });
+
+        function DeleteHookCallback(req, res) {
             const Monzo = require('monzo-js');
             var monzocredentials_local = RED.nodes.getCredentials(config.monzocreds);
             const monzo = new Monzo(monzocredentials_local.token);
@@ -76,7 +82,12 @@ module.exports = function(RED) {
                     res.send("deleted");
                 }
             });
-        });
+        }
+
+        //Set up endpoint to allow you to delete a webhook through the admin, (REQUIRES PERMISSIONS IF SET)
+        RED.httpAdmin.get('/monzo-delete-hook/:id', RED.auth.needsPermission('monzo-hook.read'), function(req, res){ DeleteHookCallback(req. res_)} );
+
+
 
         if (this.monzoConfig) {
             if (monzocredentials.token != "") {


### PR DESCRIPTION
Hey,

Turns out my previous fix didn't work properly, this does - based on feedback from https://discourse.nodered.org/t/clearing-up-a-httpnode-post/15463 - this only registers one endpoint for the app, and then when triggered goes and finds the node, so we aren't storing references to stale nodes. This means that after a redeploy it will find the updated node.

Nice side affect of this fix, is having two webhooks work much nicer now. I have two webhooks, one for my personal monzo account and one for my joint account - now each node will show the webhook for itself - which makes it easier to see what's going on.